### PR TITLE
Enhance creator notes synchronization and editing functionality

### DIFF
--- a/modal.html
+++ b/modal.html
@@ -138,6 +138,25 @@
                                     <div id="altGreetings_content" class="inline-drawer-content">
                                     </div>
                                 </div>
+                                <div class="inline-drawer">
+                                    <div class="inline-drawer-toggle inline-drawer-header inline-drawer-design"
+                                         id="CN_header">
+                                        <div style="display: flex;flex-grow: 1;">
+                                             <span class="drawer-header-item">
+                                                <b>Creator's Notes</b>
+                                                <i class="editor_maximize fa-solid fa-maximize"
+                                                   data-for="acm_creatornotes" data-i18n="[title]Expand the editor"
+                                                   title="Expand the editor"></i>
+                                            </span>
+                                        </div>
+                                        <div class="inline-drawer-icon idit fa-solid fa-circle-chevron-down down"></div>
+                                    </div>
+                                    <div class="inline-drawer-content">
+                                        <label for="acm_creatornotes" title="Description">
+                                            <textarea class="autoSetHeight" id="acm_creatornotes"></textarea>
+                                        </label>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/src/components/characters.js
+++ b/src/components/characters.js
@@ -1,30 +1,36 @@
 import {
     depth_prompt_depth_default,
     depth_prompt_role_default,
+    setCharacterId,
     talkativeness_default
 } from '../../../../../../script.js';
-import { createTagInput } from '../../../../../tags.js';
-import { displayTag } from './tags.js';
-import { getBase64Async, getIdByAvatar, updateTokenCount } from '../utils.js';
+import {createTagInput} from '../../../../../tags.js';
+import {displayTag} from './tags.js';
+import {getBase64Async, getIdByAvatar} from '../utils.js';
 import {
+    callPopup,
     characters,
     getThumbnailUrl,
+    getTokenCountAsync,
+    Popup,
+    POPUP_TYPE,
+    power_user,
+    selectCharacterById,
+    substituteParams,
     tagMap,
     unshallowCharacter,
-    getTokenCountAsync,
-    substituteParams, power_user, Popup, POPUP_TYPE, callPopup, selectCharacterById,
 } from "../constants/context.js";
-import { selectedChar, setMem_avatar } from "../constants/settings.js";
+import {selectedChar, setMem_avatar} from "../constants/settings.js";
 import {
     dupeChar,
     editCharDebounced,
-    exportChar, renameChar,
+    exportChar,
+    renameChar,
     replaceAvatar,
     saveAltGreetings
 } from "../services/characters-service.js";
-import { addAltGreetingsTrigger } from "../events/characters-events.js";
-import { closeDetails } from "./modal.js";
-import { setCharacterId } from '../../../../../../script.js';
+import {addAltGreetingsTrigger} from "../events/characters-events.js";
+import {closeDetails} from "./modal.js";
 
 
 // Function not used at this moment, leaving it here just in case
@@ -96,6 +102,7 @@ export async function fillDetails(avatar) {
     $('#acm_firstMess_tokens').text(`Tokens: ${await getTokenCountAsync(substituteParams(char.first_mes))}`);
     $('#acm_firstMess').val(char.first_mes);
     $('#altGreetings_number').text(`Numbers: ${char.data.alternate_greetings?.length ?? 0}`);
+    $('#acm_creatornotes').val(char.data?.creator_notes || char.creatorcomment);
     $('#tag_List').html(`${tagMap[char.avatar].map((tag) => displayTag(tag)).join('')}`);
     createTagInput('#input_tag', '#tag_List', { tagOptions: { removable: true } });
     displayAltGreetings(char.data.alternate_greetings).then(html => {

--- a/src/events/characters-events.js
+++ b/src/events/characters-events.js
@@ -1,16 +1,21 @@
-import { event_types, eventSource } from "../constants/context.js";
+import {event_types, eventSource} from "../constants/context.js";
 import {
-    addAltGreeting, closeCharacterPopup,
-    delAltGreeting, duplicateCharacter, exportCharacter,
-    openCharacterChat, renameCharacter, toggleAdvancedDefinitionsPopup,
+    addAltGreeting,
+    closeCharacterPopup,
+    delAltGreeting,
+    duplicateCharacter,
+    exportCharacter,
+    openCharacterChat,
+    renameCharacter,
+    toggleAdvancedDefinitionsPopup,
     toggleFavoriteStatus,
     update_avatar
 } from "../components/characters.js";
-import { generateTagFilter } from "../components/tags.js";
-import { closeDetails } from "../components/modal.js";
-import { addListenersTagFilter } from "./tags-events.js";
+import {generateTagFilter} from "../components/tags.js";
+import {closeDetails} from "../components/modal.js";
+import {addListenersTagFilter} from "./tags-events.js";
 import {checkApiAvailability, editCharDebounced, saveAltGreetings} from "../services/characters-service.js";
-import { refreshCharListDebounced } from "../components/charactersList.js";
+import {refreshCharListDebounced} from "../components/charactersList.js";
 import {selectedChar} from "../constants/settings.js";
 import {updateTokenCount} from "../utils.js";
 
@@ -18,7 +23,26 @@ export function initializeFieldUpdaters() {
     const elementsToInitialize = {
         '#acm_description': async function () {const descZone=$('#acm_description');const update={avatar:selectedChar,description:String(descZone.val()),data:{description:String(descZone.val()),},};editCharDebounced(update);await updateTokenCount('#acm_description');},
         '#acm_firstMess': async function () {const firstMesZone=$('#acm_firstMess');const update={avatar:selectedChar,first_mes:String(firstMesZone.val()),data:{first_mes:String(firstMesZone.val()),},};editCharDebounced(update);await updateTokenCount('#acm_firstMess');},
-        '#acm_creator_notes_textarea': function () {const creatorNotes=$('#acm_creator_notes_textarea');const update={avatar:selectedChar,creatorcomment:String(creatorNotes.val()),data:{creator_notes:String(creatorNotes.val()),},};editCharDebounced(update);},
+        '#acm_creatornotes': function () {
+            const creatorNotes = $('#acm_creatornotes');
+            $('#acm_creator_notes_textarea').val(String(creatorNotes.val()));
+            const update = {
+                avatar: selectedChar,
+                creatorcomment: String(creatorNotes.val()),
+                data: {creator_notes: String(creatorNotes.val()),},
+            };
+            editCharDebounced(update);
+        },
+        '#acm_creator_notes_textarea': function () {
+            const creatorNotes = $('#acm_creator_notes_textarea');
+            $('#acm_creatornotes').val(String(creatorNotes.val()));
+            const update = {
+                avatar: selectedChar,
+                creatorcomment: String(creatorNotes.val()),
+                data: {creator_notes: String(creatorNotes.val()),},
+            };
+            editCharDebounced(update);
+        },
         '#acm_character_version_textarea': function () { const update = {avatar:selectedChar,data:{character_version:String($('#acm_character_version_textarea').val()),},};editCharDebounced(update);},
         '#acm_system_prompt': async function () {const sysPrompt=$('#acm_system_prompt');const update={avatar:selectedChar,data:{system_prompt:String(sysPrompt.val()),},};editCharDebounced(update);await updateTokenCount('#acm_system_prompt');},
         '#acm_post_history_prompt': async function () {const postHistory=$('#acm_post_history_prompt');const update={avatar:selectedChar,data:{post_history_instructions:String(postHistory.val()),},};editCharDebounced(update);await updateTokenCount('#acm_post_history_prompt');},


### PR DESCRIPTION
```
### Description

This pull request introduces significant improvements to the `creator notes` feature:

- **Bi-directional Sync:** Fields `#acm_creatornotes` and `#acm_creator_notes_textarea` are now synchronized, ensuring updates are consistent and seamless.
- **Inline Drawer:** A new inline-drawer has been added for creator notes. This includes a labeled interface and an "expand editor" button for an enhanced user editing experience.
- **Prefilled Fields:** The `#acm_creatornotes` field will now be automatically prefilled for a smoother and more intuitive editing process.
