### PR TITLE
Misc changes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,6 @@
     "js": "index.js",
     "css": "style.css",
     "author": "Rendal",
-    "version": "2.3",
+    "version": "2.4",
     "homePage": "https://github.com/sakhavhyand/SillyTavern-AnotherCharManager"
 }

--- a/modal.html
+++ b/modal.html
@@ -33,10 +33,8 @@
                                     <input id="char_search_bar" class="text_pole width100p search-with-dropdown-input" type="search" data-i18n="[placeholder]Search..." placeholder="Search..." maxlength="100">
                                 </div>
                             </label>
-                            <label class="acm_checkbox">
-                                <span>Favs</span>
-                                <input id="favOnly_checkbox" type="checkbox">
-                            </label>
+                            <div id="acm_fav_filter_button" class="menu_button fa-solid fa-star fav_off faSmallFontSquareFix acm_toolbar_button" title="Show favourites only" data-i18n="[title]Show favourites only" aria-pressed="false"></div>
+                            <div id="acm_random_button" class="menu_button fa-solid fa-dice faSmallFontSquareFix acm_toolbar_button" title="Random character" data-i18n="[title]Random character"></div>
                         </form>
                         <span id="charNumber"></span>
                     </div>

--- a/src/components/characters.js
+++ b/src/components/characters.js
@@ -83,7 +83,8 @@ export async function fillDetails(avatar) {
     $('#acm_firstMess').val(char.first_mes);
     $('#altGreetings_number').text(`Numbers: ${char.data.alternate_greetings?.length ?? 0}`);
     $('#acm_creatornotes').val(char.data?.creator_notes || char.creatorcomment);
-    $('#tag_List').html(`${tagMap[char.avatar].map((tag) => displayTag(tag, 'details')).join('')}`);
+    const characterTags = Array.isArray(tagMap[char.avatar]) ? tagMap[char.avatar] : [];
+    $('#tag_List').html(`${characterTags.map((tag) => displayTag(tag, 'details')).join('')}`);
     displayAltGreetings(char.data.alternate_greetings).then(html => {
         $('#altGreetings_content').html(html);
     });

--- a/src/components/modal.js
+++ b/src/components/modal.js
@@ -12,7 +12,7 @@ import { characterId, characters, menuType, renderExtensionTemplateAsync } from 
 import { getSetting } from "../services/settings-service.js";
 import { getIdByAvatar } from "../utils.js";
 import { setCharacterId, setMenuType } from '/script.js';
-import { updateDropdownPresetNames } from "./charactersList.js";
+import { updateDropdownPresetNames, updateFavFilterButtonState } from "./charactersList.js";
 import { updateLayout } from "./characterCreation.js";
 
 /**
@@ -126,7 +126,7 @@ export function openModal() {
 
         option.selected = field === getSetting('sortingField') && order === getSetting('sortingOrder');
     });
-    document.getElementById('favOnly_checkbox').checked = getSetting('favOnly');
+    updateFavFilterButtonState(getSetting('favOnly'));
 }
 
 /**

--- a/src/components/presets.js
+++ b/src/components/presets.js
@@ -75,6 +75,11 @@ export function printCategoriesList(presetID, init = false){
     }
     else {
         preset.categories.forEach((cat,index) => {
+            const mandatoryTags = Array.isArray(cat.mandatoryTags)
+                ? cat.mandatoryTags
+                : (Array.isArray(cat.tags) ? cat.tags : []);
+            const facultativeTags = Array.isArray(cat.facultativeTags) ? cat.facultativeTags : [];
+            const excludedTags = Array.isArray(cat.excludedTags) ? cat.excludedTags : [];
             const catHTML = `
                         <div data-catid="${index}">
                             <div class="acm_catList">
@@ -85,22 +90,57 @@ export function printCategoriesList(presetID, init = false){
                                     <div class="menu_button fa-solid fa-trash cat_delete" title="Delete category"></div>
                                 </div>
                             </div>
-                            <div id="acm_catTagList_${index}" class="acm_catTagList"></div>
+                            <div class="acm_catTagSection">
+                                <div class="acm_catTagHeader">
+                                    <span>Mandatory Tags</span>
+                                    <i class="fa-solid fa-plus tag addCatTag" data-tagtype="mandatory"></i>
+                                </div>
+                                <div id="acm_catTagList_${index}_mandatory" class="acm_catTagList" data-tagtype="mandatory"></div>
+                            </div>
+                            <div class="acm_catTagSection">
+                                <div class="acm_catTagHeader">
+                                    <span>At least one tag</span>
+                                    <i class="fa-solid fa-plus tag addCatTag" data-tagtype="facultative"></i>
+                                </div>
+                                <div id="acm_catTagList_${index}_facultative" class="acm_catTagList" data-tagtype="facultative"></div>
+                            </div>
+                            <div class="acm_catTagSection">
+                                <div class="acm_catTagHeader">
+                                    <span>Excluded tags</span>
+                                    <i class="fa-solid fa-plus tag addCatTag" data-tagtype="excluded"></i>
+                                </div>
+                                <div id="acm_catTagList_${index}_excluded" class="acm_catTagList" data-tagtype="excluded"></div>
+                            </div>
                         </div>`;
             const catElement = $(catHTML);
-            const catTagList = catElement.find(`#acm_catTagList_${index}`);
-            if (cat.tags) {
-                cat.tags.forEach(tag => {
-                    catTagList.append(displayTag(tag, 'category'));
-                });
-            }
-            catTagList.append(`<label for="input_cat_tag_${index}" title="Search or create a tag.">
-                                    <input id="input_cat_tag_${index}" class="text_pole tag_input wide100p margin0 ui-autocomplete-input" placeholder="Search tags" maxlength="50" autocomplete="off" style="display: none">
+            const catTagListMandatory = catElement.find(`#acm_catTagList_${index}_mandatory`);
+            const catTagListFacultative = catElement.find(`#acm_catTagList_${index}_facultative`);
+            const catTagListExcluded = catElement.find(`#acm_catTagList_${index}_excluded`);
+
+            mandatoryTags.forEach(tag => {
+                catTagListMandatory.append(displayTag(tag, 'category'));
+            });
+            facultativeTags.forEach(tag => {
+                catTagListFacultative.append(displayTag(tag, 'category'));
+            });
+            excludedTags.forEach(tag => {
+                catTagListExcluded.append(displayTag(tag, 'category'));
+            });
+
+            catTagListMandatory.append(`<label for="input_cat_tag_${index}_mandatory" title="Search or create a tag.">
+                                    <input id="input_cat_tag_${index}_mandatory" class="text_pole tag_input wide100p margin0 ui-autocomplete-input" placeholder="Search tags" maxlength="50" autocomplete="off" style="display: none">
                                 </label>`);
-            catTagList.append(`<i class="fa-solid fa-plus tag addCatTag"></i>`);
+            catTagListFacultative.append(`<label for="input_cat_tag_${index}_facultative" title="Search or create a tag.">
+                                    <input id="input_cat_tag_${index}_facultative" class="text_pole tag_input wide100p margin0 ui-autocomplete-input" placeholder="Search tags" maxlength="50" autocomplete="off" style="display: none">
+                                </label>`);
+            catTagListExcluded.append(`<label for="input_cat_tag_${index}_excluded" title="Search or create a tag.">
+                                    <input id="input_cat_tag_${index}_excluded" class="text_pole tag_input wide100p margin0 ui-autocomplete-input" placeholder="Search tags" maxlength="50" autocomplete="off" style="display: none">
+                                </label>`);
             catContainer.append(catElement);
             $('#acm_custom_categories').append(catContainer);
-            acmCreateTagInput(`#input_cat_tag_${index}`, `#acm_catTagList_${index}`, { tagOptions: { removable: true } }, 'category');
+            acmCreateTagInput(`#input_cat_tag_${index}_mandatory`, `#acm_catTagList_${index}_mandatory`, { tagOptions: { removable: true } }, 'category');
+            acmCreateTagInput(`#input_cat_tag_${index}_facultative`, `#acm_catTagList_${index}_facultative`, { tagOptions: { removable: true } }, 'category');
+            acmCreateTagInput(`#input_cat_tag_${index}_excluded`, `#acm_catTagList_${index}_excluded`, { tagOptions: { removable: true } }, 'category');
         });
         makeCategoryDraggable("#catContainer");
     }
@@ -196,21 +236,21 @@ export function renameCategory(preset, category, newName) {
  * @param {string} selectedCat The identifier for the selected category.
  * @return {string} The identifier of the toggled category.
  */
-export function toggleTagButton(button, selectedCat) {
+export function toggleTagButton(button, selectedCat, tagType = 'mandatory') {
     if (button.hasClass('addCatTag')) {
         button
             .removeClass('addCatTag')
             .addClass('cancelCatTag')
             .removeClass('fa-plus')
             .addClass('fa-minus');
-        $(`#input_cat_tag_${selectedCat}`).show();
+        $(`#input_cat_tag_${selectedCat}_${tagType}`).show();
     } else {
         button
             .addClass('addCatTag')
             .removeClass('cancelCatTag')
             .addClass('fa-plus')
             .removeClass('fa-minus');
-        $(`#input_cat_tag_${selectedCat}`).hide();
+        $(`#input_cat_tag_${selectedCat}_${tagType}`).hide();
     }
 }
 

--- a/src/components/tags.js
+++ b/src/components/tags.js
@@ -114,8 +114,9 @@ function acmSelectTag(event, ui, listSelector, { tagListOptions = {}, mode = 'cl
         case 'category': {
             const selectedPreset = $('#preset_selector option:selected').data('preset');
             const selectedCat = $(listSelector).find('label').closest('[data-catid]').data('catid');
+            const tagType = $(listSelector).data('tagtype') || 'mandatory';
             $(listSelector).find('label').before(displayTag(tag.id, 'category'));
-            addTagToCategory(selectedPreset, selectedCat, tag.id);
+            addTagToCategory(selectedPreset, selectedCat, tag.id, tagType);
             break;
         }
         case 'multiple': {

--- a/src/constants/settings.js
+++ b/src/constants/settings.js
@@ -33,6 +33,11 @@ export const defaultSettings = {
     dropdownUI: false,
     dropdownMode: "allTags",
     presetId: 0,
+    dropdownOpenSections: {
+        allTags: [],
+        custom: [],
+        creators: []
+    },
     dropdownPresets: [
         { name: "Preset 1", categories: [] },
         { name: "Preset 2", categories: [] },

--- a/src/css/charactersList.css
+++ b/src/css/charactersList.css
@@ -203,6 +203,10 @@
     margin: 5px;
 }
 
+.acm_toolbar_button {
+    margin: 5px 0;
+}
+
 #charNumber {
     padding: 7px 2px;
     min-width: fit-content;

--- a/src/css/presets.css
+++ b/src/css/presets.css
@@ -19,6 +19,19 @@
 .acm_catTagList {
     display: flex;
     margin: 0 5px 5px 5px;
+    flex-wrap: wrap;
+    gap: 5px;
+}
+
+.acm_catTagSection {
+    margin-bottom: 8px;
+}
+
+.acm_catTagHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin: 2px 5px 4px 5px;
 }
 
 #preset_selector {

--- a/src/css/tags.css
+++ b/src/css/tags.css
@@ -30,6 +30,17 @@
     width: 50%;
 }
 
+#tag_List {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    max-height: min(30vh, 220px);
+    overflow-y: auto;
+    padding-right: 4px;
+    padding-bottom: 53px;
+    box-sizing: border-box;
+}
+
 .acm_tagQuery_container {
     display: flex;
     flex-direction: column;

--- a/src/events/charactersList-events.js
+++ b/src/events/charactersList-events.js
@@ -1,9 +1,14 @@
 import {
     refreshCharListDebounced,
-    selectAndDisplay, toggleFavoritesOnly, toggleTagQueries,
+    selectAndDisplay,
+    selectRandomCharacter,
+    toggleFavoritesOnly,
+    toggleTagQueries,
     updateSearchFilter,
     updateSortOrder
 } from "../components/charactersList.js";
+import { openCharacterChat } from "../components/characters.js";
+import { getSetting } from "../services/settings-service.js";
 import { toggleCharacterCreationPopup } from "../components/characterCreation.js";
 
 /**
@@ -17,6 +22,15 @@ export function initializeCharactersListEvents() {
     // Trigger when a character is selected in the list
     $(document).on('click', '.char_select', function () {
         selectAndDisplay(this.dataset.avatar);
+    });
+
+    $(document).on('dblclick', '.char_select', async function () {
+        await selectAndDisplay(this.dataset.avatar);
+        openCharacterChat();
+    });
+
+    $(document).on('dblclick', '.char_selected', function () {
+        openCharacterChat();
     });
 }
 
@@ -45,8 +59,12 @@ export function initializeToolbarEvents() {
         updateSearchFilter($(this).val());
     });
 
-    $('#favOnly_checkbox').on("change", function () {
-        toggleFavoritesOnly(this.checked);
+    $('#acm_fav_filter_button').on("click", function () {
+        toggleFavoritesOnly(!getSetting('favOnly'));
+    });
+
+    $('#acm_random_button').on("click", function () {
+        selectRandomCharacter();
     });
 
     $('#acm_character_import_button').on("click", function () {

--- a/src/events/presets-events.js
+++ b/src/events/presets-events.js
@@ -65,20 +65,23 @@ export function initializePresetsEvents() {
     // Trigger on a click on the add tag button in a category
     $(document).on("click", ".addCatTag", function () {
         const selectedCat = $(this).closest('[data-catid]').data('catid');
-        toggleTagButton($(this), selectedCat);
+        const tagType = $(this).data('tagtype') || 'mandatory';
+        toggleTagButton($(this), selectedCat, tagType);
     });
 
     // Trigger on a click on the minus tag button in a category
     $(document).on("click", ".cancelCatTag", function () {
         const selectedCat = $(this).closest('[data-catid]').data('catid');
-        toggleTagButton($(this), selectedCat);
+        const tagType = $(this).data('tagtype') || 'mandatory';
+        toggleTagButton($(this), selectedCat, tagType);
     });
 
     $(document).on("click", ".tag_cat_remove", function () {
         const selectedPreset = $('#preset_selector option:selected').data('preset');
         const selectedCat = $(this).closest('[data-catid]').data('catid');
         const selectedTag = $(this).closest('[data-tagid]').data('tagid');
-        removeTagFromCategory(selectedPreset, selectedCat, selectedTag);
+        const tagType = $(this).closest('.acm_catTagList').data('tagtype') || 'mandatory';
+        removeTagFromCategory(selectedPreset, selectedCat, selectedTag, tagType);
         $(this).closest('[data-tagid]').remove();
     });
 }

--- a/src/services/charactersList-service.js
+++ b/src/services/charactersList-service.js
@@ -124,7 +124,7 @@ export function sortCharAR(chars, sort_data, sort_order) {
                 comparison = a[sort_data].localeCompare(b[sort_data]);
                 break;
             case 'tags':
-                comparison = tagMap[a.avatar].length - tagMap[b.avatar].length;
+                comparison = (tagMap[a.avatar]?.length || 0) - (tagMap[b.avatar]?.length || 0);
                 break;
             case 'date_last_chat':
                 comparison = b[sort_data] - a[sort_data];


### PR DESCRIPTION
This PR adds:
* random button that selects random character visible under current filters. In dropdown UI random will only select from opened dropdowns.
* ability to double click character on the list to open chat
* counter of currently visible characters (Total characters: 750 -> Characters: 128/750) (counting only works for classic UI)
* memory of previously opened dropdown sections in dropdown UI. This is saved per browser. Each section has it's own save. When you reopen manager the same dropdown sections will be visible as last time you used it.
* Custom profiles for Dropdown UI now have "All of", "At least one of" and "Exclude" tags, like regular filters. This is backwards compatible, and previously configured profiles will have "All of those tags" already configured.

Also
* "Favs" checkbox is changed to star icon to get space for new button
* When there are too many tags in character profile scrollbar will appear to scroll trough them