### PR TITLE
Random button and other changes

### DIFF
--- a/css/charactersList.css
+++ b/css/charactersList.css
@@ -209,6 +209,19 @@
     margin: 5px;
 }
 
+.acm_toolbar_button {
+    margin: 5px 0;
+}
+
+.fav_on {
+    color: var(--golden) !important;
+}
+
+.fav_off {
+    color: var(--SmartThemeBodyColor);
+    opacity: 0.6;
+}
+
 #charNumber {
     padding: 7px 2px;
     min-width: fit-content;

--- a/css/presets.css
+++ b/css/presets.css
@@ -16,6 +16,20 @@
     border: 1px solid var(--SmartThemeBorderColor);
 }
 
+.acm_catTagSections {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin: 5px;
+}
+
+.acm_catTagSection h5 {
+    margin: 5px 0;
+    font-size: 0.9em;
+    color: var(--SmartThemeBodyColor);
+    opacity: 0.8;
+}
+
 .acm_catTagList {
     display: flex;
     margin: 0 5px 5px 5px;

--- a/scripts/classes/CharListManager.js
+++ b/scripts/classes/CharListManager.js
@@ -39,6 +39,19 @@ export class CharListManager {
             this.selectAndDisplay(event.currentTarget.dataset.avatar);
         });
 
+        // Trigger when a character card is double-clicked to open chat
+        $(document).on('dblclick', '.char_select', async (event) => {
+            event.stopPropagation();
+            await this.selectAndDisplay(event.currentTarget.dataset.avatar);
+            this.charManager.openCharacterChat();
+        });
+
+        // Trigger when an already selected character is double-clicked to open chat
+        $(document).on('dblclick', '.char_selected', (event) => {
+            event.stopPropagation();
+            this.charManager.openCharacterChat();
+        });
+
         this.eventManager.on('charList:refresh', (data) => {
             this.refreshCharListDebounced(data);
         });
@@ -95,9 +108,15 @@ export class CharListManager {
             this.refreshCharListDebounced();
         });
 
-        $('#favOnly_checkbox').on('change', (event) => {
-            this.settings.updateSetting('favOnly', event.currentTarget.checked);
+        $('#acm_fav_filter_button').on('click', () => {
+            const isEnabled = !this.settings.getSetting('favOnly');
+            this.settings.updateSetting('favOnly', isEnabled);
+            this.updateFavFilterButtonState(isEnabled);
             this.refreshCharListDebounced();
+        });
+
+        $('#acm_random_button').on('click', () => {
+            this.selectRandomCharacter();
         });
 
         $('#acm_character_import_button').on('click', function () {
@@ -116,6 +135,138 @@ export class CharListManager {
             $(event.currentTarget).closest('[data-tagid]').remove();
             this.refreshCharListDebounced(true);
         });
+    }
+
+    /**
+     * Updates the visual state of the favorites filter button based on whether the filter is enabled.
+     *
+     * @param {boolean} isEnabled - Whether the favorites filter is currently enabled.
+     * @return {void}
+     */
+    updateFavFilterButtonState(isEnabled) {
+        const button = document.getElementById('acm_fav_filter_button');
+        if (!button) return;
+        
+        button.classList.toggle('fav_on', isEnabled);
+        button.classList.toggle('fav_off', !isEnabled);
+        button.setAttribute('aria-pressed', isEnabled ? 'true' : 'false');
+    }
+
+    /**
+     * Updates the character count display based on the current filtering state.
+     * Format: "Characters: visible/total" in classic UI with filters,
+     *         "Characters: total/total" in dropdown UI or classic UI without filters.
+     *
+     * @param {number} visibleCount - The number of currently visible/filtered characters.
+     * @return {void}
+     */
+    updateCharacterCount(visibleCount) {
+        const total = this.st.characters.length;
+        const dropdownUI = this.settings.getSetting('dropdownUI');
+        const hasFilters = this.hasActiveFilters();
+        
+        let displayText;
+        if (dropdownUI) {
+            displayText = `Characters: ${total}/${total}`;
+        } else {
+            const count = hasFilters ? visibleCount : total;
+            displayText = `Characters: ${count}/${total}`;
+        }
+        
+        $('#charNumber').empty().append(displayText);
+    }
+
+    /**
+     * Checks if any active filters are currently applied.
+     *
+     * @return {boolean} True if any filters are active, false otherwise.
+     */
+    hasActiveFilters() {
+        const hasSearchValue = this.settings.searchValue && this.settings.searchValue.trim() !== '';
+        const hasFavFilter = this.settings.getSetting('favOnly');
+        const hasMandatoryTags = $('#acm_mandatoryTags > span[data-tagid]').length > 0;
+        const hasFacultativeTags = $('#acm_facultativeTags > span[data-tagid]').length > 0;
+        const hasExcludedTags = $('#acm_excludedTags > span[data-tagid]').length > 0;
+        
+        return hasSearchValue || hasFavFilter || hasMandatoryTags || hasFacultativeTags || hasExcludedTags;
+    }
+
+    /**
+     * Checks if a character matches the filters defined in a custom category.
+     * Applies filtering in order: excluded tags -> mandatory tags -> facultative tags.
+     *
+     * @param {Object} item - The character item to check
+     * @param {Object} category - The category with mandatoryTags, facultativeTags, excludedTags arrays
+     * @return {boolean} True if the character matches the category filters
+     */
+    matchesCategoryFilters(item, category) {
+        const characterTags = this.st.tagMap[item.avatar] || [];
+        
+        // Normalize category for backwards compatibility
+        const normalizedCategory = this.presetManager.normalizeCategory(category);
+        const { mandatoryTags = [], facultativeTags = [], excludedTags = [] } = normalizedCategory;
+        
+        // First: Exclude characters with any excluded tags
+        if (excludedTags.length > 0) {
+            const hasExcludedTag = characterTags.some(tagId => excludedTags.includes(String(tagId)));
+            if (hasExcludedTag) return false;
+        }
+        
+        // Second: Check if character has ALL mandatory tags
+        if (mandatoryTags.length > 0) {
+            const hasAllMandatoryTags = mandatoryTags.every(tagId => 
+                characterTags.includes(String(tagId))
+            );
+            if (!hasAllMandatoryTags) return false;
+        }
+        
+        // Third: Check if character has at least ONE facultative tag (if any are defined)
+        if (facultativeTags.length > 0) {
+            const hasAtLeastOneFacultativeTag = facultativeTags.some(tagId => 
+                characterTags.includes(String(tagId))
+            );
+            if (!hasAtLeastOneFacultativeTag) return false;
+        }
+        
+        return true;
+    }
+
+    /**
+     * Selects a random character from the currently visible/filtered character list.
+     * In dropdown UI mode, only selects from characters in opened dropdown sections.
+     *
+     * @return {void}
+     */
+    selectRandomCharacter() {
+        const dropdownUI = this.settings.getSetting('dropdownUI');
+        let selectableCharacters = [];
+
+        if (dropdownUI) {
+            // In dropdown mode, only get characters from opened sections
+            const openDropdowns = document.querySelectorAll('#character-list .dropdown-container.open');
+            openDropdowns.forEach(dropdown => {
+                const cards = dropdown.querySelectorAll('[data-avatar]');
+                cards.forEach(card => {
+                    const avatar = card.dataset.avatar;
+                    if (avatar) selectableCharacters.push(avatar);
+                });
+            });
+        } else {
+            // In classic mode, get all filtered characters (not just visible in DOM)
+            if (this.currentFilteredList && this.currentFilteredList.length > 0) {
+                selectableCharacters = this.currentFilteredList.map(char => char.avatar);
+            }
+        }
+
+        if (selectableCharacters.length === 0) {
+            console.log('No characters to select from');
+            return;
+        }
+
+        const randomIndex = Math.floor(Math.random() * selectableCharacters.length);
+        const randomAvatar = selectableCharacters[randomIndex];
+        
+        this.selectAndDisplay(randomAvatar, true);
     }
 
     /**
@@ -240,7 +391,7 @@ export class CharListManager {
                     comparison = a[sort_data].localeCompare(b[sort_data]);
                     break;
                 case 'tags':
-                    comparison = this.st.tagMap[a.avatar].length - this.st.tagMap[b.avatar].length;
+                    comparison = (this.st.tagMap[a.avatar]?.length || 0) - (this.st.tagMap[b.avatar]?.length || 0);
                     break;
                 case 'date_last_chat':
                     comparison = b[sort_data] - a[sort_data];
@@ -376,11 +527,24 @@ export class CharListManager {
         await this.charManager.fillDetails(avatar);
         await this.charManager.fillAdvancedDefinitions(avatar);
         window.acmIsUpdatingDetails = false;
-        if(scrollTo) {
+        
+        if(scrollTo && this.virtualScroller) {
+            // Use VirtualScroller in classic view
             this.virtualScroller.scrollToAvatar(avatar);
+        } else if(scrollTo) {
+            // Use native scroll in dropdown view
+            const element = document.querySelector(`[data-avatar="${avatar}"]`);
+            if (element) {
+                element.scrollIntoView({ block: 'center', behavior: 'smooth' });
+            }
         }
 
-        document.querySelector(`[data-avatar="${avatar}"]`).classList.replace('char_select','char_selected');
+        // Update selected state only if element exists in DOM
+        const avatarElement = document.querySelector(`[data-avatar="${avatar}"]`);
+        if (avatarElement) {
+            avatarElement.classList.replace('char_select','char_selected');
+        }
+        
         document.getElementById('char-sep').style.display = 'block';
         document.getElementById('char-details').classList.add('open');
     }
@@ -396,12 +560,16 @@ export class CharListManager {
         const filteredChars = this.searchAndFilter();
 
         if(filteredChars.length === 0){
+            this.currentFilteredList = [];
             $('#character-list').html('<span>Hmm, it seems like the character you\'re looking for is hiding out in a secret lair. Try searching for someone else instead.</span>');
         }
         else {
             const dropdownUI = this.settings.getSetting('dropdownUI');
             const dropdownMode = this.settings.getSetting('dropdownMode');
             const sortedList = this.sortCharAR(filteredChars);
+            
+            // Store the current filtered and sorted list for random selection
+            this.currentFilteredList = sortedList;
 
             if (dropdownUI && ['allTags', 'custom', 'creators'].includes(dropdownMode)) {
                 $('#character-list').html(this.generateDropdown(sortedList, dropdownMode));
@@ -409,10 +577,20 @@ export class CharListManager {
                 list.querySelectorAll('.dropdown-container').forEach(container => {
                     const title = container.querySelector('.dropdown-title');
                     const content = container.querySelector('.dropdown-content');
+                    const data = container.dataset;
+                    
+                    // Restore content for sections that were previously open
+                    if (container.classList.contains('open')) {
+                        content.appendChild(this.generateDropdownContent(sortedList, data.type, data.content));
+                    }
+                    
                     title.addEventListener('click', () => {
                         const isOpen = container.classList.toggle('open');
+                        
+                        // Save the open/closed state
+                        this.updateDropdownSectionState(data.type, data.content, isOpen);
+                        
                         if (isOpen) {
-                            const data = container.dataset;
                             content.appendChild(this.generateDropdownContent(sortedList, data.type, data.content));
                         } else {
                             content.innerText = '';
@@ -423,7 +601,7 @@ export class CharListManager {
                 this.renderCharactersListHTML(sortedList, preserveScroll);
             }
         }
-        $('#charNumber').empty().append(`Total characters : ${this.st.characters.length}`);
+        this.updateCharacterCount(filteredChars.length);
         this.eventManager.emit('character_list_refreshed');
     }
 
@@ -464,17 +642,19 @@ export class CharListManager {
                 if (categories.length === 0) {
                     return 'Looks like our categories went on vacation! 🏖️ Check back when they\'re done sunbathing!';
                 }
-                return categories.map(category => {
-                    const members = category.tags;
+                return categories.map((category, categoryIndex) => {
+                    // Normalize category for backwards compatibility
+                    category = this.presetManager.normalizeCategory(category);
+                    
                     const charactersForCat = sortedList
-                        .filter(item => members.every(memberId => this.st.tagMap[item.avatar]?.includes(String(memberId))))
+                        .filter(item => this.matchesCategoryFilters(item, category))
                         .map(item => item.avatar);
                     if (charactersForCat.length === 0) return '';
                     return this.createDropdownContainer(
                         category.name,
                         charactersForCat.length,
                         'custom',
-                        category.tags.join(','),
+                        `${preset}-${categoryIndex}`, // Store preset and category index
                     );
                 }).join('');
             },
@@ -518,13 +698,58 @@ export class CharListManager {
      * @return {string} The HTML string representing the dropdown container.
      */
     createDropdownContainer(title, count, type, content) {
-        return `<div class="dropdown-container" data-type="${type}" data-content="${content}">
+        const isOpen = this.isDropdownSectionOpen(type, content);
+        const openClass = isOpen ? ' open' : '';
+        
+        return `<div class="dropdown-container${openClass}" data-type="${type}" data-content="${content}">
         <div class="dropdown-title inline-drawer-toggle inline-drawer-header inline-drawer-design">
             ${title} (${count})
         </div>
         <div class="dropdown-content character-list">
         </div>
     </div>`;
+    }
+
+    /**
+     * Checks if a dropdown section should be open based on saved state.
+     *
+     * @param {string} type - The dropdown type (allTags, custom, creators).
+     * @param {string} content - The section identifier.
+     * @return {boolean} True if the section should be open.
+     */
+    isDropdownSectionOpen(type, content) {
+        const openSections = this.settings.getSetting('dropdownOpenSections') || {};
+        const sectionsForType = openSections[type] || [];
+        return sectionsForType.includes(String(content));
+    }
+
+    /**
+     * Updates the saved state of a dropdown section (opened/closed).
+     *
+     * @param {string} type - The dropdown type (allTags, custom, creators).
+     * @param {string} content - The section identifier.
+     * @param {boolean} isOpen - Whether the section is now open.
+     * @return {void}
+     */
+    updateDropdownSectionState(type, content, isOpen) {
+        const openSections = this.settings.getSetting('dropdownOpenSections') || {
+            allTags: [],
+            custom: [],
+            creators: []
+        };
+        
+        const sectionsForType = openSections[type] || [];
+        const contentStr = String(content);
+        const index = sectionsForType.indexOf(contentStr);
+        
+        if (isOpen && index === -1) {
+            sectionsForType.push(contentStr);
+        } else if (!isOpen && index !== -1) {
+            sectionsForType.splice(index, 1);
+        }
+        
+        openSections[type] = sectionsForType;
+        this.settings.updateSetting('dropdownOpenSections', openSections);
     }
 
     /**
@@ -555,14 +780,21 @@ export class CharListManager {
                 return container;
             },
             custom: () => {
-                const tags = content
-                    .split(',')
-                    .map(t => t.trim())
-                    .filter(t => t.length > 0);
-                const filteredCharacters = sortedList.filter(item => {
-                    const charTags = this.st.tagMap[item.avatar] || [];
-                    return tags.every(tag => charTags.includes(tag));
-                });
+                // Parse preset and category index from content (format: "presetId-categoryIndex")
+                const [presetId, categoryIndex] = content.split('-').map(Number);
+                const category = this.presetManager.getPreset(presetId).categories[categoryIndex];
+                
+                if (!category) {
+                    return document.createDocumentFragment();
+                }
+                
+                // Normalize category for backwards compatibility
+                const normalizedCategory = this.presetManager.normalizeCategory(category);
+                
+                const filteredCharacters = sortedList.filter(item => 
+                    this.matchesCategoryFilters(item, normalizedCategory)
+                );
+                
                 const container = document.createDocumentFragment();
                 filteredCharacters.forEach(character => {
                     const block = this.createCharacterBlock(character.avatar);

--- a/scripts/classes/CharacterManager.js
+++ b/scripts/classes/CharacterManager.js
@@ -266,7 +266,10 @@ export class CharacterManager {
         $('#acm_firstMess').val(char.first_mes);
         $('#altGreetings_number').text(`Numbers: ${char.data.alternate_greetings?.length ?? 0}`);
         $('#acm_creatornotes').val(char.data?.creator_notes || char.creatorcomment);
-        $('#tag_List').html(`${this.st.tagMap[char.avatar].map((tag) => this.tagManager.displayTag(tag, 'details')).join('')}`);
+        
+        const charTags = this.st.tagMap[char.avatar] || [];
+        $('#tag_List').html(`${charTags.map((tag) => this.tagManager.displayTag(tag, 'details')).join('')}`);
+        
         this.displayAltGreetings(char.data.alternate_greetings).then(html => {
             $('#altGreetings_content').html(html);
         });

--- a/scripts/classes/ModalManager.js
+++ b/scripts/classes/ModalManager.js
@@ -174,8 +174,10 @@ export class ModalManager {
      * @return {void} This function does not return a value.
      */
     closeModal() {
-        this.closeDetails();
-        setCharacterId(getIdByAvatar(this.settings.mem_avatar));
+        this.closeDetails(false);
+        if (this.settings.mem_avatar !== undefined) {
+            setCharacterId(getIdByAvatar(this.settings.mem_avatar));
+        }
         setMenuType(this.settings.mem_menu);
         this.settings.setMem_avatar(undefined);
 

--- a/scripts/classes/ModalManager.js
+++ b/scripts/classes/ModalManager.js
@@ -145,7 +145,10 @@ export class ModalManager {
 
             option.selected = field === this.settings.getSetting('sortingField') && order === this.settings.getSetting('sortingOrder');
         });
-        document.getElementById('favOnly_checkbox').checked = this.settings.getSetting('favOnly');
+        
+        const favOnly = this.settings.getSetting('favOnly');
+        this.charListManager.updateFavFilterButtonState(favOnly);
+        
         this.eventManager.emit('modal:opened');
     }
 

--- a/scripts/classes/TagManager.js
+++ b/scripts/classes/TagManager.js
@@ -137,11 +137,17 @@ export class TagManager {
             case 'category': {
                 const selectedPreset = $('#preset_selector option:selected').data('preset');
                 const selectedCat = $(listSelector).find('label').closest('[data-catid]').data('catid');
+                
+                // Determine tag type from the parent section
+                const tagSection = $(listSelector).closest('[data-tagtype]');
+                const tagType = tagSection.length > 0 ? tagSection.data('tagtype') : 'mandatory';
+                
                 $(listSelector).find('label').before(this.displayTag(tag.id, 'category'));
                 this.eventManager.emit('tag:addTagToCat', {
                     presetId: selectedPreset,
                     categoryId: selectedCat,
                     tagId: tag.id,
+                    tagType: tagType
                 });
                 break;
             }

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -9,6 +9,11 @@ export const defaultSettings = Object.freeze({
     favOnly: false,
     dropdownUI: false,
     dropdownMode: 'allTags',
+    dropdownOpenSections: {
+        allTags: [],
+        custom: [],
+        creators: []
+    },
     presetId: 0,
     dropdownPresets: [
         { name: 'Preset 1', categories: [] },

--- a/templates/modal.html
+++ b/templates/modal.html
@@ -31,10 +31,8 @@
                         <input id="char_search_bar" class="text_pole width100p search-with-dropdown-input" type="search" data-i18n="[placeholder]Search..." placeholder="Search..." maxlength="100">
                     </div>
                 </label>
-                <label class="acm_checkbox">
-                    <span>Favs</span>
-                    <input id="favOnly_checkbox" type="checkbox">
-                </label>
+                <div id="acm_fav_filter_button" class="menu_button fa-solid fa-star fav_off faSmallFontSquareFix acm_toolbar_button" title="Show favourites only" data-i18n="[title]Show favourites only" aria-pressed="false"></div>
+                <div id="acm_random_button" class="menu_button fa-solid fa-dice faSmallFontSquareFix acm_toolbar_button" title="Random character" data-i18n="[title]Random character"></div>
             </form>
             <span id="charNumber"></span>
         </div>


### PR DESCRIPTION
This PR adds:

- random button that selects random character visible under current filters. In dropdown UI random will only select from opened dropdowns.
- ability to double click character on the list to open chat
- counter of currently visible characters (Total characters: 750 -> Characters: 128/750) (counting only works for classic UI)
- memory of previously opened dropdown sections in dropdown UI. This is saved per browser. Each section has it's own save. When you reopen manager the same dropdown sections will be visible as last time you used it.
- Custom profiles for Dropdown UI now have "All of", "At least one of" and "Exclude" tags, like regular filters. This is backwards compatible, and previously configured profiles will have "All of those tags" already configured.

Also
"Favs" checkbox is changed to star icon to get space for new button